### PR TITLE
Added CAS error constants

### DIFF
--- a/src/Constants.php
+++ b/src/Constants.php
@@ -20,4 +20,14 @@ class Constants extends \SimpleSAML\XML\Constants
      * The format to express a timestamp in CAS
      */
     final public const DATETIME_FORMAT = 'Y-m-d\\TH:i:sp';
+
+    /**
+     * The INVALID_TICKET CAS error
+     */
+    final public const ERR_INVALID_TICKET = 'INVALID_TICKET';
+
+    /**
+     * The INVALID_SERVICE CAS error
+     */
+    final public const ERR_INVALID_SERVICe = 'INVALID_SERVICE';
 }

--- a/src/Constants.php
+++ b/src/Constants.php
@@ -22,12 +22,22 @@ class Constants extends \SimpleSAML\XML\Constants
     final public const DATETIME_FORMAT = 'Y-m-d\\TH:i:sp';
 
     /**
-     * The INVALID_TICKET CAS error
+     * The INTERNAL_ERROR CAS error
      */
-    final public const ERR_INVALID_TICKET = 'INVALID_TICKET';
+    final public const ERR_INTERNAL_ERROR = 'INTERNAL_ERROR';
+
+    /**
+     * The INVALID_REQUEST CAS error
+     */
+    final public const ERR_INVALID_REQUEST = 'INVALID_REQUEST';
 
     /**
      * The INVALID_SERVICE CAS error
      */
     final public const ERR_INVALID_SERVICE = 'INVALID_SERVICE';
+
+    /**
+     * The INVALID_TICKET CAS error
+     */
+    final public const ERR_INVALID_TICKET = 'INVALID_TICKET';
 }

--- a/src/Constants.php
+++ b/src/Constants.php
@@ -29,5 +29,5 @@ class Constants extends \SimpleSAML\XML\Constants
     /**
      * The INVALID_SERVICE CAS error
      */
-    final public const ERR_INVALID_SERVICe = 'INVALID_SERVICE';
+    final public const ERR_INVALID_SERVICE = 'INVALID_SERVICE';
 }


### PR DESCRIPTION
While trying to deploy a simplesamlphp installation using the `simplesamlphp/simplesamlphp-module-casserver@dev-master` I found that these constants were missing from the `SimpleSAML\CAS\Constants` class.

If you'd rather these only be a part of the casserver module, I can get a PR going on that repo instead.